### PR TITLE
fix: parallel groupsで6つ以上のAgentが表示されない問題を修正

### DIFF
--- a/cc-flow-web/src/components/workflow-editor/StepGroupNode/AgentList.tsx
+++ b/cc-flow-web/src/components/workflow-editor/StepGroupNode/AgentList.tsx
@@ -14,7 +14,7 @@ export default function AgentList({ agents, onRemoveAgent }: AgentListProps) {
   }
 
   return (
-    <div className="space-y-2 max-h-80 overflow-y-auto">
+    <div className="space-y-2">
       {agents.map((agent, index) => {
         const agentName = typeof agent === 'string' ? agent : agent.name;
         const category = typeof agent === 'string' ? 'default' : (agent.category || 'default');

--- a/cc-flow-web/src/components/workflow-editor/StepGroupNode/StepGroupNode.tsx
+++ b/cc-flow-web/src/components/workflow-editor/StepGroupNode/StepGroupNode.tsx
@@ -98,13 +98,13 @@ export default function StepGroupNode({ id, data, selected }: NodeProps) {
   // Calculate dynamic height based on number of agents
   const agentCount = stepData.agents.length;
   const headerHeight = 64; // pt-16 = 64px
-  const dropZoneHeight = 150; // Fixed height for drop zone
+  const dropZoneHeight = agentCount >= 10 ? 0 : 150; // Hide drop zone when 10 agents reached
   const agentItemHeight = 52; // Height per agent item including gap
   const padding = 24; // px-3 pb-3 = 12px * 2
   const titleHeight = 28; // Title height with margin
   const minAgentAreaHeight = 100; // Minimum height for agent area
 
-  // Calculate agent area height (minimum 100px for "No agents yet")
+  // Calculate agent area height - expand to show all agents
   const agentAreaHeight =
     agentCount > 0
       ? agentCount * agentItemHeight + 24 // 24px for padding
@@ -189,8 +189,9 @@ export default function StepGroupNode({ id, data, selected }: NodeProps) {
           </div>
 
           {/* Fixed height drop zone at bottom */}
-          <div
-            className={`rounded-xl border-2 border-dashed p-4 transition-all ${
+          {agentCount < 10 && (
+            <div
+              className={`rounded-xl border-2 border-dashed p-4 transition-all ${
               isDragOver
                 ? "border-purple-400/70 bg-purple-100"
                 : "border-purple-400/40 bg-gray-50"
@@ -226,6 +227,7 @@ export default function StepGroupNode({ id, data, selected }: NodeProps) {
               </p>
             </div>
           </div>
+          )}
         </div>
 
         {/* Source handle on the right */}


### PR DESCRIPTION
## Summary
- parallel groupsで6つ以上のAgentを追加すると表示されなくなるバグを修正
- 10個のAgentが登録されたらDropゾーンを自動的に非表示に

## 変更内容

### AgentList.tsx
- `max-h-80` (320px)の高さ制限を削除
- すべてのAgentを表示できるように変更

### StepGroupNode.tsx
- Agentの数に応じてノードの高さが動的に拡大するように変更
- 10個のAgentが登録された場合、Dropゾーンを非表示にする条件付きレンダリングを追加
- `dropZoneHeight`を動的に計算（10個以上で0px）

## Test plan
- [ ] parallel groupsに6個以上のAgentを追加して、すべて表示されることを確認
- [ ] 10個のAgentを追加した際に、Dropゾーンが非表示になることを確認
- [ ] ノードの高さがAgentの数に応じて適切に拡大することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Agent area now auto-expands to display all agents without scrolling.
  - Drop zone is hidden when 10 agents are present, preventing additional drops.
  - Dynamic sizing updates ensure consistent layout as agents are added.

- Style
  - Removed fixed max-height and vertical scrolling from the agent list for a cleaner, continuous layout.
  - Improved layout behavior by conditionally rendering the bottom drop zone only when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->